### PR TITLE
Handle agent login authentication error

### DIFF
--- a/nananom-farms-frontend/src/services/auth.js
+++ b/nananom-farms-frontend/src/services/auth.js
@@ -104,18 +104,18 @@ export const loginAgent = async (credentials) => {
   try {
     const response = await post('/api/agent/auth', {
       action: 'login',
-      username: credentials.username,
+      email: credentials.username, // Backend expects 'email' field
       password: credentials.password
     }, {}, false);
 
     if (response && response.success && response.token && response.user) {
       const { token, user } = response;
-      storeAuthData(token, 'agent', user.id, user.username);
+      storeAuthData(token, 'agent', user.id, user.email);
       return {
         token,
         role: 'agent',
         userId: user.id,
-        userName: user.username,
+        userName: user.email, // Use email as username for agents
         user
       };
     } else {
@@ -141,12 +141,12 @@ export const registerAgent = async (userData) => {
     
     if (response && response.success && response.token && response.user) {
       const { token, user } = response;
-      storeAuthData(token, 'agent', user.id, user.username);
+      storeAuthData(token, 'agent', user.id, user.email);
       return {
         token,
         role: 'agent',
         userId: user.id,
-        userName: user.username,
+        userName: user.email, // Use email as username for agents
         user
       };
     }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix agent login and registration to send `email` instead of `username` to match backend API requirements.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The frontend was sending a `username` field for agent authentication, but the backend API specifically expects an `email` field. This change maps the frontend's 'username' input (which can be an email) to the `email` parameter for the backend, resolving the 400 Bad Request error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6168dfff-2587-4ecc-b1ae-bcc28f51072c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6168dfff-2587-4ecc-b1ae-bcc28f51072c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>